### PR TITLE
Switch flat map to Web Mercator cover + clamp and fix long-press

### DIFF
--- a/lib/features/map/flat_map_geometry.dart
+++ b/lib/features/map/flat_map_geometry.dart
@@ -1,6 +1,8 @@
 import 'dart:math' as math;
 import 'dart:ui';
 
+const double _kWebMercatorMaxLatitude = 85.05112878;
+
 class GeoBounds {
   const GeoBounds({
     required this.minLon,
@@ -57,11 +59,12 @@ class WebMercatorProjection {
 
   Offset project(double lon, double lat) {
     final x = (lon + 180.0) / 360.0;
-    final clampedLat = lat.clamp(-85.0511, 85.0511).toDouble();
-    final rad = clampedLat * math.pi / 180.0;
-    final y =
-        0.5 -
-        math.log((1 + math.sin(rad)) / (1 - math.sin(rad))) / (4 * math.pi);
+    final clampedLat = lat
+        .clamp(-_kWebMercatorMaxLatitude, _kWebMercatorMaxLatitude)
+        .toDouble();
+    final radians = clampedLat * math.pi / 180.0;
+    final sinPhi = math.sin(radians);
+    final y = 0.5 - math.log((1 + sinPhi) / (1 - sinPhi)) / (4 * math.pi);
     return Offset(x, y);
   }
 

--- a/lib/features/map/map_viewport_constraints.dart
+++ b/lib/features/map/map_viewport_constraints.dart
@@ -1,0 +1,69 @@
+import 'dart:math' as math;
+import 'dart:ui';
+
+/// Computes cover scale and translation constraints for the flat Web Mercator map.
+class MapViewportConstraints {
+  const MapViewportConstraints({required this.worldSize});
+
+  final double worldSize;
+
+  double coverScale(Size viewport) {
+    if (viewport.isEmpty) {
+      return 1.0;
+    }
+    final scaleX = viewport.width / worldSize;
+    final scaleY = viewport.height / worldSize;
+    return math.max(scaleX, scaleY);
+  }
+
+  MapViewportTransform clamp({
+    required Size viewport,
+    required double scale,
+    required Offset translation,
+  }) {
+    final minScale = coverScale(viewport);
+    final clampedScale = math.max(scale, minScale);
+    final Offset clampedTranslation = _clampTranslation(
+      viewport: viewport,
+      scale: clampedScale,
+      translation: translation,
+    );
+    return MapViewportTransform(
+      scale: clampedScale,
+      translation: clampedTranslation,
+    );
+  }
+
+  Offset centeredTranslation({required Size viewport, required double scale}) {
+    final worldWidth = worldSize * scale;
+    final worldHeight = worldSize * scale;
+    final tx = (viewport.width - worldWidth) / 2;
+    final ty = (viewport.height - worldHeight) / 2;
+    return Offset(
+      tx.clamp(viewport.width - worldWidth, 0.0),
+      ty.clamp(viewport.height - worldHeight, 0.0),
+    );
+  }
+
+  Offset _clampTranslation({
+    required Size viewport,
+    required double scale,
+    required Offset translation,
+  }) {
+    final worldWidth = worldSize * scale;
+    final worldHeight = worldSize * scale;
+    final minTx = viewport.width - worldWidth;
+    final minTy = viewport.height - worldHeight;
+    return Offset(
+      translation.dx.clamp(minTx, 0.0),
+      translation.dy.clamp(minTy, 0.0),
+    );
+  }
+}
+
+class MapViewportTransform {
+  const MapViewportTransform({required this.scale, required this.translation});
+
+  final double scale;
+  final Offset translation;
+}

--- a/lib/features/map/widgets/map_gesture_layer.dart
+++ b/lib/features/map/widgets/map_gesture_layer.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+/// Captures tap/long-press gestures across the entire map without blocking pan/zoom.
+class MapGestureLayer extends StatefulWidget {
+  const MapGestureLayer({
+    required this.child,
+    this.onLongPress,
+    this.onTap,
+    this.enabled = true,
+    super.key,
+  });
+
+  final Widget child;
+  final ValueChanged<Offset>? onLongPress;
+  final VoidCallback? onTap;
+  final bool enabled;
+
+  @override
+  State<MapGestureLayer> createState() => _MapGestureLayerState();
+}
+
+class _MapGestureLayerState extends State<MapGestureLayer> {
+  static const Duration _longPressDuration = Duration(milliseconds: 500);
+  static const double _moveThreshold = 12.0;
+
+  Timer? _timer;
+  Offset? _downPosition;
+  bool _longPressTriggered = false;
+  bool _movementExceeded = false;
+  int _pointerCount = 0;
+  int? _primaryPointer;
+
+  @override
+  void dispose() {
+    _cancelTimer();
+    super.dispose();
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (!widget.enabled) {
+      return;
+    }
+    _pointerCount += 1;
+    if (_pointerCount == 1) {
+      _primaryPointer = event.pointer;
+      _movementExceeded = false;
+      _startTimer(event.localPosition);
+    } else {
+      _movementExceeded = true;
+      _cancelTimer();
+    }
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    if (!widget.enabled ||
+        _primaryPointer == null ||
+        event.pointer != _primaryPointer ||
+        _longPressTriggered) {
+      return;
+    }
+    final down = _downPosition;
+    if (down == null) {
+      return;
+    }
+    final dx = event.localPosition.dx - down.dx;
+    final dy = event.localPosition.dy - down.dy;
+    final distanceSquared = dx * dx + dy * dy;
+    if (distanceSquared >= _moveThreshold * _moveThreshold) {
+      _movementExceeded = true;
+      _cancelTimer();
+    }
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    if (!widget.enabled) {
+      _resetPointers();
+      return;
+    }
+    _pointerCount = math.max(0, _pointerCount - 1);
+    if (event.pointer == _primaryPointer) {
+      final didTriggerLongPress = _longPressTriggered;
+      final shouldTap =
+          !didTriggerLongPress && !_movementExceeded && _downPosition != null;
+      _resetPrimaryState();
+      if (shouldTap) {
+        widget.onTap?.call();
+      }
+    }
+    if (_pointerCount == 0) {
+      _primaryPointer = null;
+      _movementExceeded = false;
+    }
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    _resetPointers();
+  }
+
+  void _startTimer(Offset position) {
+    _downPosition = position;
+    _longPressTriggered = false;
+    _timer?.cancel();
+    _timer = Timer(_longPressDuration, () {
+      final down = _downPosition;
+      if (down == null) {
+        return;
+      }
+      _longPressTriggered = true;
+      widget.onLongPress?.call(down);
+    });
+  }
+
+  void _cancelTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  void _resetPrimaryState() {
+    _cancelTimer();
+    _downPosition = null;
+    _longPressTriggered = false;
+  }
+
+  void _resetPointers() {
+    _pointerCount = 0;
+    _primaryPointer = null;
+    _movementExceeded = false;
+    _resetPrimaryState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      behavior: HitTestBehavior.deferToChild,
+      onPointerDown: _handlePointerDown,
+      onPointerMove: _handlePointerMove,
+      onPointerUp: _handlePointerUp,
+      onPointerCancel: _handlePointerCancel,
+      child: widget.child,
+    );
+  }
+}

--- a/test/features/map/flat_map_geometry_test.dart
+++ b/test/features/map/flat_map_geometry_test.dart
@@ -30,4 +30,18 @@ void main() {
       expect(restored.dy, closeTo(point.dy, 1e-6));
     }
   });
+
+  test('WebMercator projection centers equator and clamps latitude', () {
+    const projection = WebMercatorProjection();
+    final equator = projection.project(0, 0);
+    expect(equator.dx, closeTo(0.5, 1e-9));
+    expect(equator.dy, closeTo(0.5, 1e-9));
+
+    final clampedNorth = projection.project(0, 90);
+    final clampedSouth = projection.project(0, -90);
+    final maxNorth = projection.project(0, 85.05112878);
+    final maxSouth = projection.project(0, -85.05112878);
+    expect(clampedNorth.dy, closeTo(maxNorth.dy, 1e-9));
+    expect(clampedSouth.dy, closeTo(maxSouth.dy, 1e-9));
+  });
 }

--- a/test/features/map/map_gesture_layer_test.dart
+++ b/test/features/map/map_gesture_layer_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:world_visit_app/features/map/widgets/map_gesture_layer.dart';
+
+void main() {
+  testWidgets(
+    'MapGestureLayer triggers long press anywhere on the map surface',
+    (tester) async {
+      Offset? longPressPosition;
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: SizedBox(
+            width: 200,
+            height: 200,
+            child: MapGestureLayer(
+              onLongPress: (pos) => longPressPosition = pos,
+              child: Container(color: Colors.blue),
+            ),
+          ),
+        ),
+      );
+
+      final gesture = await tester.startGesture(const Offset(100, 100));
+      await tester.pump(const Duration(milliseconds: 600));
+      expect(longPressPosition, isNotNull);
+      expect(longPressPosition!.dx, closeTo(100, 1));
+      expect(longPressPosition!.dy, closeTo(100, 1));
+      await gesture.up();
+    },
+  );
+
+  testWidgets('MapGestureLayer reports tap when movement is small', (
+    tester,
+  ) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 200,
+          height: 200,
+          child: MapGestureLayer(
+            onTap: () => tapped = true,
+            child: Container(color: Colors.red),
+          ),
+        ),
+      ),
+    );
+
+    final gesture = await tester.startGesture(const Offset(50, 80));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.up();
+    expect(tapped, isTrue);
+  });
+}

--- a/test/features/map/map_viewport_constraints_test.dart
+++ b/test/features/map/map_viewport_constraints_test.dart
@@ -1,0 +1,51 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:world_visit_app/features/map/map_viewport_constraints.dart';
+
+void main() {
+  const constraints = MapViewportConstraints(worldSize: 4096);
+
+  test('coverScale picks the larger axis to cover the screen', () {
+    const viewport = Size(800, 600);
+    final scale = constraints.coverScale(viewport);
+    expect(scale, viewport.width / 4096);
+
+    const tallViewport = Size(600, 1200);
+    final tallScale = constraints.coverScale(tallViewport);
+    expect(tallScale, tallViewport.height / 4096);
+  });
+
+  test('clamp enforces minimum scale and translation bounds', () {
+    const viewport = Size(600, 1400);
+    final minScale = constraints.coverScale(viewport);
+    final transform = constraints.clamp(
+      viewport: viewport,
+      scale: minScale / 2,
+      translation: const Offset(-2000, -2000),
+    );
+    expect(transform.scale, minScale);
+    expect(
+      transform.translation.dx,
+      closeTo(viewport.width - 4096 * minScale, 1e-6),
+    );
+    expect(
+      transform.translation.dy,
+      closeTo(viewport.height - 4096 * minScale, 1e-6),
+    );
+  });
+
+  test('centeredTranslation recenters the world', () {
+    const viewport = Size(1080, 720);
+    final scale = constraints.coverScale(viewport);
+    final translation = constraints.centeredTranslation(
+      viewport: viewport,
+      scale: scale,
+    );
+    expect(translation.dx <= 0, isTrue);
+    expect(translation.dy <= 0, isTrue);
+    final worldWidth = 4096 * scale;
+    expect(translation.dx, closeTo((viewport.width - worldWidth) / 2, 1e-6));
+  });
+}


### PR DESCRIPTION
Web Mercator式を固定（85.0511 clamp）

初期表示＝cover、minScale固定、tx/ty clampで白禁止

long-pressはMapGestureLayerで全面対応（500ms、移動でキャンセル）

既存LOD/SelectionSheet/PlaceDetail導線は維持

新規テスト（geometry / viewport constraints / gesture layer）