### PR TITLE
Fix map load states and trips sorting

### DIFF
--- a/lib/data/db/user_setting_repository.dart
+++ b/lib/data/db/user_setting_repository.dart
@@ -1,0 +1,31 @@
+import 'package:sqflite/sqflite.dart';
+
+class UserSettingRepository {
+  const UserSettingRepository(this.db);
+
+  final Database db;
+
+  Future<void> setValue(String key, String value) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db.insert('user_setting', {
+      'key': key,
+      'value': value,
+      'updated_at': now,
+    }, conflictAlgorithm: ConflictAlgorithm.replace);
+  }
+
+  Future<String?> getValue(String key) async {
+    final rows = await db.query(
+      'user_setting',
+      columns: ['value'],
+      where: 'key = ?',
+      whereArgs: [key],
+      limit: 1,
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    final value = rows.first['value'];
+    return value?.toString();
+  }
+}

--- a/lib/features/map/data/map_dataset_guard.dart
+++ b/lib/features/map/data/map_dataset_guard.dart
@@ -1,0 +1,24 @@
+import 'package:world_visit_app/features/map/data/flat_map_loader.dart';
+
+/// Ensures that decoded datasets contain usable geometries/polygons.
+class MapDatasetGuard {
+  const MapDatasetGuard._();
+
+  static void ensureUsable(FlatMapDataset dataset, {required String label}) {
+    if (dataset.geometries.isEmpty) {
+      throw MapDatasetException('$label dataset has no geometries.');
+    }
+    if (dataset.polygons.isEmpty) {
+      throw MapDatasetException('$label dataset has no polygons.');
+    }
+  }
+}
+
+class MapDatasetException implements Exception {
+  const MapDatasetException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/lib/features/trips/trip_sort.dart
+++ b/lib/features/trips/trip_sort.dart
@@ -1,5 +1,58 @@
 import 'package:world_visit_app/data/db/visit_repository.dart';
 
+enum TripSortOption { recent, nameEn, nameJa, score }
+
+abstract interface class TripSortable {
+  VisitRecord get visit;
+  String? get placeNameJa;
+  String? get placeNameEn;
+  int get placeMaxLevel;
+  int get placeVisitCount;
+}
+
+extension TripSortOptionLabel on TripSortOption {
+  String get label {
+    switch (this) {
+      case TripSortOption.recent:
+        return '時系列';
+      case TripSortOption.nameEn:
+        return '国名 (EN)';
+      case TripSortOption.nameJa:
+        return '国名 (JA)';
+      case TripSortOption.score:
+        return 'スコア';
+    }
+  }
+
+  String get storageValue {
+    switch (this) {
+      case TripSortOption.recent:
+        return 'recent';
+      case TripSortOption.nameEn:
+        return 'name_en';
+      case TripSortOption.nameJa:
+        return 'name_ja';
+      case TripSortOption.score:
+        return 'score';
+    }
+  }
+}
+
+TripSortOption? tripSortOptionFromStorage(String? raw) {
+  switch (raw) {
+    case 'recent':
+      return TripSortOption.recent;
+    case 'name_en':
+      return TripSortOption.nameEn;
+    case 'name_ja':
+      return TripSortOption.nameJa;
+    case 'score':
+      return TripSortOption.score;
+    default:
+      return null;
+  }
+}
+
 int compareVisitRecords(VisitRecord a, VisitRecord b) {
   final aStart = a.startDate;
   final bStart = b.startDate;
@@ -12,4 +65,73 @@ int compareVisitRecords(VisitRecord a, VisitRecord b) {
     return 1;
   }
   return b.createdAt.compareTo(a.createdAt);
+}
+
+int compareTrips(TripSortable a, TripSortable b, TripSortOption option) {
+  switch (option) {
+    case TripSortOption.recent:
+      return compareVisitRecords(a.visit, b.visit);
+    case TripSortOption.nameEn:
+      return _compareByName(
+        a,
+        b,
+        primary: (entry) => entry.placeNameEn,
+        secondary: (entry) => entry.placeNameJa,
+      );
+    case TripSortOption.nameJa:
+      return _compareByName(
+        a,
+        b,
+        primary: (entry) => entry.placeNameJa,
+        secondary: (entry) => entry.placeNameEn,
+      );
+    case TripSortOption.score:
+      final levelComparison = b.placeMaxLevel.compareTo(a.placeMaxLevel);
+      if (levelComparison != 0) {
+        return levelComparison;
+      }
+      final visitCountComparison = b.placeVisitCount.compareTo(
+        a.placeVisitCount,
+      );
+      if (visitCountComparison != 0) {
+        return visitCountComparison;
+      }
+      return _compareByName(
+        a,
+        b,
+        primary: (entry) => entry.placeNameEn,
+        secondary: (entry) => entry.placeNameJa,
+      );
+  }
+}
+
+int _compareByName(
+  TripSortable a,
+  TripSortable b, {
+  required String? Function(TripSortable entry) primary,
+  required String? Function(TripSortable entry) secondary,
+}) {
+  final nameA = _resolveName(a, primary, secondary);
+  final nameB = _resolveName(b, primary, secondary);
+  final cmp = nameA.compareTo(nameB);
+  if (cmp != 0) {
+    return cmp;
+  }
+  return compareVisitRecords(a.visit, b.visit);
+}
+
+String _resolveName(
+  TripSortable entry,
+  String? Function(TripSortable entry) primary,
+  String? Function(TripSortable entry) secondary,
+) {
+  final primaryName = primary(entry)?.toLowerCase();
+  if (primaryName != null && primaryName.isNotEmpty) {
+    return primaryName;
+  }
+  final fallback = secondary(entry)?.toLowerCase();
+  if (fallback != null && fallback.isNotEmpty) {
+    return fallback;
+  }
+  return entry.visit.placeCode.toLowerCase();
 }

--- a/test/data/db/user_setting_repository_test.dart
+++ b/test/data/db/user_setting_repository_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:world_visit_app/data/db/app_database.dart';
+import 'package:world_visit_app/data/db/user_setting_repository.dart';
+
+void main() {
+  sqfliteFfiInit();
+
+  test('user setting repository saves and restores values', () async {
+    final db = await AppDatabase(
+      factory: databaseFactoryFfi,
+    ).open(path: inMemoryDatabasePath);
+    final repo = UserSettingRepository(db);
+
+    expect(await repo.getValue('trips_sort'), isNull);
+    await repo.setValue('trips_sort', 'recent');
+    expect(await repo.getValue('trips_sort'), 'recent');
+    await repo.setValue('trips_sort', 'score');
+    expect(await repo.getValue('trips_sort'), 'score');
+
+    await db.close();
+  });
+}

--- a/test/features/map/map_dataset_guard_test.dart
+++ b/test/features/map/map_dataset_guard_test.dart
@@ -1,0 +1,53 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:world_visit_app/features/map/data/flat_map_loader.dart';
+import 'package:world_visit_app/features/map/data/map_dataset_guard.dart';
+import 'package:world_visit_app/features/map/data/spatial_index.dart';
+import 'package:world_visit_app/features/map/flat_map_geometry.dart';
+
+void main() {
+  test('throws when dataset has no geometries', () {
+    final dataset = FlatMapDataset(
+      geometries: const {},
+      spatialIndex: SpatialIndex<String>(),
+    );
+    expect(
+      () => MapDatasetGuard.ensureUsable(dataset, label: 'empty'),
+      throwsA(isA<MapDatasetException>()),
+    );
+  });
+
+  test('passes when dataset contains at least one polygon', () {
+    final polygon = MapPolygon(
+      geometryId: 'JP',
+      drawOrder: 1,
+      rings: [
+        const [
+          Offset(0.1, 0.1),
+          Offset(0.2, 0.1),
+          Offset(0.2, 0.2),
+          Offset(0.1, 0.2),
+          Offset(0.1, 0.1),
+        ],
+      ],
+    );
+    final geometry = CountryGeometry(
+      geometryId: 'JP',
+      drawOrder: 1,
+      polygons: [polygon],
+      bounds: const GeoBounds(minLon: 0, minLat: 0, maxLon: 1, maxLat: 1),
+      worldBounds: const Rect.fromLTWH(0.1, 0.1, 0.1, 0.1),
+    );
+    final spatialIndex = SpatialIndex<String>()
+      ..insert(geometry.worldBounds, geometry.geometryId);
+    final dataset = FlatMapDataset(
+      geometries: {'JP': geometry},
+      spatialIndex: spatialIndex,
+    );
+    expect(
+      () => MapDatasetGuard.ensureUsable(dataset, label: 'non-empty'),
+      returnsNormally,
+    );
+  });
+}

--- a/test/features/map/map_page_test.dart
+++ b/test/features/map/map_page_test.dart
@@ -2,15 +2,140 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
+import 'package:world_visit_app/data/db/app_database.dart';
+import 'package:world_visit_app/features/map/data/flat_map_loader.dart';
+import 'package:world_visit_app/features/map/data/spatial_index.dart';
+import 'package:world_visit_app/features/map/flat_map_geometry.dart';
 import 'package:world_visit_app/features/map/map_page.dart';
 
 void main() {
-  sqfliteFfiInit();
-  databaseFactory = databaseFactoryFfi;
-
-  testWidgets('Flat map renders without token', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: MapPage()));
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(find.textContaining('経国値'), findsOneWidget);
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
   });
+
+  testWidgets('Flat map renders once place data is available', (tester) async {
+    await tester.runAsync(() async {
+      final db = await _preparePlaceDatabase();
+      final dataset = _fakeDataset();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MapPage(
+            mapLoader: _FakeFlatMapLoader(dataset),
+            openDatabase: () async => db,
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump();
+      expect(find.textContaining('経国値'), findsOneWidget);
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+    });
+  });
+
+  testWidgets('Error UI appears when dataset load fails', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MapPage(
+          mapLoader: _FailingFlatMapLoader(),
+          openDatabase: _unusedDatabase,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.text('地図データの読み込みに失敗しました'), findsOneWidget);
+    expect(find.text('再読み込み'), findsOneWidget);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+}
+
+Future<Database> _unusedDatabase() {
+  throw StateError('openDatabase should not be called when loader fails');
+}
+
+Future<Database> _preparePlaceDatabase() async {
+  final appDb = AppDatabase(factory: databaseFactoryFfi);
+  final db = await appDb.open(path: inMemoryDatabasePath);
+  await _insertPlaceWithStats(db);
+  return db;
+}
+
+Future<void> _insertPlaceWithStats(Database db) async {
+  const placeCode = 'JP';
+  final now = DateTime.now().millisecondsSinceEpoch;
+  await db.insert('place', {
+    'place_code': placeCode,
+    'type': 'country',
+    'name_ja': '日本',
+    'name_en': 'Japan',
+    'is_active': 1,
+    'sort_order': 392,
+    'geometry_id': '392',
+    'updated_at': now,
+  });
+  await db.insert('place_stats', {
+    'place_code': placeCode,
+    'max_level': 0,
+    'visit_count': 0,
+    'last_visit_date': null,
+    'updated_at': now,
+  }, conflictAlgorithm: ConflictAlgorithm.replace);
+}
+
+class _FailingFlatMapLoader extends FlatMapLoader {
+  _FailingFlatMapLoader();
+
+  @override
+  Future<FlatMapDataset> loadCountries110m() {
+    throw StateError('countries_110m missing');
+  }
+
+  @override
+  Future<FlatMapDataset> loadCountries50m() {
+    throw StateError('countries_50m missing');
+  }
+}
+
+class _FakeFlatMapLoader extends FlatMapLoader {
+  _FakeFlatMapLoader(this.dataset);
+
+  final FlatMapDataset dataset;
+
+  @override
+  Future<FlatMapDataset> loadCountries110m() async => dataset;
+
+  @override
+  Future<FlatMapDataset> loadCountries50m() async => dataset;
+}
+
+FlatMapDataset _fakeDataset() {
+  final polygon = MapPolygon(
+    geometryId: '392',
+    drawOrder: 1,
+    rings: [
+      const [
+        Offset(0.2, 0.2),
+        Offset(0.3, 0.2),
+        Offset(0.3, 0.3),
+        Offset(0.2, 0.3),
+        Offset(0.2, 0.2),
+      ],
+    ],
+  );
+  final geometry = CountryGeometry(
+    geometryId: '392',
+    drawOrder: 1,
+    polygons: [polygon],
+    bounds: const GeoBounds(minLon: 130, minLat: 30, maxLon: 140, maxLat: 40),
+    worldBounds: const Rect.fromLTRB(0.2, 0.2, 0.3, 0.3),
+  );
+  final spatialIndex = SpatialIndex<String>()
+    ..insert(geometry.worldBounds, geometry.geometryId);
+  return FlatMapDataset(
+    geometries: {'392': geometry},
+    spatialIndex: spatialIndex,
+  );
 }

--- a/test/features/trips/trip_sort_test.dart
+++ b/test/features/trips/trip_sort_test.dart
@@ -4,7 +4,7 @@ import 'package:world_visit_app/data/db/visit_repository.dart';
 import 'package:world_visit_app/features/trips/trip_sort.dart';
 
 void main() {
-  test('compareTripView sorts start_date desc and then created_at', () {
+  test('compareVisitRecords sorts start_date desc and then created_at', () {
     final visitA = VisitRecord(
       visitId: 'a',
       placeCode: 'JP',
@@ -54,4 +54,113 @@ void main() {
     list.sort(compareVisitRecords);
     expect(list.map((e) => e.visitId), ['a', 'b', 'c', 'd']);
   });
+
+  test('compareTrips sorts by English name', () {
+    final a = _FakeTrip(
+      visit: _visit('1', startDate: '2024-01-01'),
+      nameEn: 'Canada',
+      nameJa: 'カナダ',
+      level: 2,
+      visitCount: 3,
+    );
+    final b = _FakeTrip(
+      visit: _visit('2', startDate: '2024-02-01'),
+      nameEn: 'Brazil',
+      nameJa: 'ブラジル',
+      level: 1,
+      visitCount: 1,
+    );
+    final c = _FakeTrip(
+      visit: _visit('3', startDate: '2023-12-01'),
+      nameEn: 'Denmark',
+      nameJa: 'デンマーク',
+      level: 5,
+      visitCount: 10,
+    );
+    final list = [a, b, c];
+    list.sort((x, y) => compareTrips(x, y, TripSortOption.nameEn));
+    expect(list.map((e) => e.visit.visitId), ['2', '1', '3']);
+  });
+
+  test('compareTrips sorts by score', () {
+    final a = _FakeTrip(
+      visit: _visit('1'),
+      nameEn: 'Japan',
+      nameJa: '日本',
+      level: 3,
+      visitCount: 5,
+    );
+    final b = _FakeTrip(
+      visit: _visit('2'),
+      nameEn: 'France',
+      nameJa: 'フランス',
+      level: 3,
+      visitCount: 10,
+    );
+    final c = _FakeTrip(
+      visit: _visit('3'),
+      nameEn: 'Australia',
+      nameJa: 'オーストラリア',
+      level: 4,
+      visitCount: 2,
+    );
+    final list = [a, b, c];
+    list.sort((x, y) => compareTrips(x, y, TripSortOption.score));
+    expect(list.map((e) => e.visit.visitId), ['3', '2', '1']);
+  });
+
+  test('sort option storage round trip works', () {
+    for (final option in TripSortOption.values) {
+      final stored = option.storageValue;
+      expect(tripSortOptionFromStorage(stored), option);
+    }
+    expect(tripSortOptionFromStorage('unknown'), isNull);
+  });
+}
+
+VisitRecord _visit(String id, {String? startDate}) {
+  final parsed = int.tryParse(id) ?? 0;
+  return VisitRecord(
+    visitId: id,
+    placeCode: 'XX$id',
+    title: 'Trip $id',
+    startDate: startDate,
+    endDate: null,
+    level: 3,
+    note: null,
+    createdAt: parsed,
+    updatedAt: parsed,
+  );
+}
+
+class _FakeTrip implements TripSortable {
+  _FakeTrip({
+    required this.visit,
+    required String nameEn,
+    required String nameJa,
+    required int level,
+    required int visitCount,
+  }) : _nameEn = nameEn,
+       _nameJa = nameJa,
+       _level = level,
+       _visitCount = visitCount;
+
+  @override
+  final VisitRecord visit;
+  final String _nameEn;
+  final String _nameJa;
+  final int _level;
+  final int _visitCount;
+
+  @override
+  String? get placeNameEn => _nameEn;
+
+  @override
+  String? get placeNameJa => _nameJa;
+
+  @override
+  int get placeMaxLevel => _level;
+
+  @override
+  int get placeVisitCount => _visitCount;
 }


### PR DESCRIPTION
Mapが白くなる/沈黙するのを Loading/Ready/Error + Guard + Retry UIで修正

TagPickerの無限ローディングを終端する状態管理に修正

Tripsの並び替え（時系列/英名/和名/スコア）と永続化を実装