### PR TITLE
Rename app from Keikoku to ExploNation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# world-visit-app
+# ExploNation
 
-Keikoku (world visit) MVP の Flutter クライアントです。すべての地図・マスターデータをアプリ内に同梱し、オフラインでも旅行ログを編集できます。
+世界を探索しながら色塗りする Flutter アプリです。すべての地図・マスターデータをアプリ内に同梱し、オフラインでも旅行ログを編集できます。
 
 ## セットアップ
 
@@ -32,10 +32,10 @@ Keikoku (world visit) MVP の Flutter クライアントです。すべての地
 - macOS ランナーでは iOS 向けに `flutter build ios --no-codesign` を実行します。
 - これらに先立ち `flutter pub get` を毎回実行し、依存を同期します。
 
-## Import / Export (keikoku v1)
+## Import / Export (explonation v1)
 
 - Settings → Data management から JSON / CSV v1 の ImportFlow を利用できます。
-- JSON: `format="keikoku"`, `version=1`。`place_code` で Places を参照し、未知コードはエラー扱いでスキップします。未定義フィールドは無視されます。
+- JSON: `format="explonation"`, `version=1`。`place_code` で Places を参照し、未知コードはエラー扱いでスキップします。未定義フィールドは無視されます。
 - CSV: UTF-8 (BOM 任意) でヘッダ必須。`tags` は `;` 区切りで、タグに `;` を含めることはできません。
 - ImportFlow は「ファイル選択 → Preflight → Preview（集計） → 実行 → 結果/issue一覧」を踏襲し、デフォルトは不正行スキップ、厳格モードでは 1 件のエラーで全体中断します。
 

--- a/assets/places/place_aliases.json
+++ b/assets/places/place_aliases.json
@@ -954,6 +954,6 @@
   ],
   "XNC": [
     "XNC",
-    "Keikoku"
+    "ExploNation"
   ]
 }

--- a/assets/places/place_master.json
+++ b/assets/places/place_master.json
@@ -2362,8 +2362,8 @@
   {
     "place_code": "XNC",
     "type": "special",
-    "name_en": "Keikoku",
-    "name_ja": "Keikoku",
+    "name_en": "ExploNation",
+    "name_ja": "ExploNation",
     "is_active": false,
     "geometry_id": "XNC",
     "sort_order": 2370,

--- a/lib/data/db/app_database.dart
+++ b/lib/data/db/app_database.dart
@@ -77,6 +77,6 @@ CREATE TABLE IF NOT EXISTS meta (
 
   Future<String> _defaultDbPath() async {
     final databasesPath = await getDatabasesPath();
-    return p.join(databasesPath, 'keikoku.db');
+    return p.join(databasesPath, 'explonation.db');
   }
 }

--- a/lib/features/import_export/application/import_export_service.dart
+++ b/lib/features/import_export/application/import_export_service.dart
@@ -13,7 +13,7 @@ import 'package:world_visit_app/features/import_export/model/import_issue.dart';
 import 'package:world_visit_app/features/import_export/model/import_preview.dart';
 import 'package:world_visit_app/util/normalize.dart';
 
-const _jsonFormat = 'keikoku';
+const _jsonFormat = 'explonation';
 const _jsonVersion = 1;
 const _dateRegex = r'^\d{4}-\d{2}-\d{2}$';
 final _datePattern = RegExp(_dateRegex);
@@ -72,7 +72,7 @@ class ImportExportService {
     final payload = await _buildExportPayload();
     final dir = directory ?? await getApplicationDocumentsDirectory();
     final file = File(
-      p.join(dir.path, 'keikoku_export_${_fileTimestamp()}.json'),
+      p.join(dir.path, 'explonation_export_${_fileTimestamp()}.json'),
     );
     await file.writeAsString(jsonEncode(payload.toJson()));
     return file;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: world_visit_app
-description: "Scaffolding for the Keikoku (world visit) Flutter application."
+description: "ExploNation - Flutter application for coloring the world through travel."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev

--- a/test/features/import_export/import_service_test.dart
+++ b/test/features/import_export/import_service_test.dart
@@ -29,7 +29,7 @@ void main() {
     'JSON import skips unknown place_code and inserts valid visit',
     () async {
       final payload = jsonEncode({
-        'format': 'keikoku',
+        'format': 'explonation',
         'version': 1,
         'exported_at': '2024-01-01T00:00:00Z',
         'tags': [
@@ -104,7 +104,7 @@ void main() {
     await db.insert('visit_tag', {'visit_id': 'v-up', 'tag_id': 'obsolete'});
 
     final payload = jsonEncode({
-      'format': 'keikoku',
+      'format': 'explonation',
       'version': 1,
       'exported_at': '2024-01-01T00:00:00Z',
       'tags': [

--- a/tool/places/generate_places.mjs
+++ b/tool/places/generate_places.mjs
@@ -14,8 +14,8 @@ const contestedTerritories = new Set(['HK', 'MO', 'PR', 'TW', 'PS', 'EH', 'XK'])
 const manualPlace = {
   place_code: 'XNC',
   type: 'special',
-  name_en: 'Keikoku',
-  name_ja: 'Keikoku',
+  name_en: 'ExploNation',
+  name_ja: 'ExploNation',
   is_active: false,
   geometry_id: 'XNC',
 };
@@ -116,7 +116,7 @@ function buildAliases(places) {
     aliases[place.place_code] = Array.from(set).filter(Boolean);
   }
   if (!aliases.XNC) {
-    aliases.XNC = ['Keikoku'];
+    aliases.XNC = ['ExploNation'];
   }
   return aliases;
 }


### PR DESCRIPTION
Update all references to the old "Keikoku" name across the codebase:
- README, pubspec description
- Database filename (keikoku.db -> explonation.db)
- Import/export format and filename
- XNC place entry in master data and aliases
- Place generation tool